### PR TITLE
`user_account` -> `admin_account`로 관리자 회원 테이블명 변경

### DIFF
--- a/src/main/java/com/fastcampus/board_admin_project/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/board_admin_project/domain/AdminAccount.java
@@ -22,7 +22,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
   @Id
   @Column(length = 50)
   private String userId;
@@ -38,9 +38,9 @@ public class UserAccount extends AuditingFields {
   @Setter private String memo;
 
 
-  protected UserAccount() {}
+  protected AdminAccount() {}
 
-  private UserAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+  private AdminAccount(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
     this.userId = userId;
     this.userPassword = userPassword;
     this.roleTypes = roleTypes;
@@ -51,12 +51,12 @@ public class UserAccount extends AuditingFields {
     this.modifiedBy = createdBy;
   }
 
-  public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-    return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, null);
+  public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+    return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, null);
   }
 
-  public static UserAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
-    return new UserAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
+  public static AdminAccount of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, String createdBy) {
+    return new AdminAccount(userId, userPassword, roleTypes, email, nickname, memo, createdBy);
   }
 
   public void addRoleType(RoleType roleType) {
@@ -74,7 +74,7 @@ public class UserAccount extends AuditingFields {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof UserAccount that)) return false;
+    if (!(o instanceof AdminAccount that)) return false;
     return this.getUserId() != null && this.getUserId().equals(that.getUserId());
   }
 

--- a/src/main/java/com/fastcampus/board_admin_project/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/board_admin_project/dto/AdminAccountDto.java
@@ -1,0 +1,58 @@
+package com.fastcampus.board_admin_project.dto;
+
+import com.fastcampus.board_admin_project.domain.AdminAccount;
+import com.fastcampus.board_admin_project.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return AdminAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    }
+
+
+
+    public static AdminAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new AdminAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/board_admin_project/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/board_admin_project/dto/UserAccountDto.java
@@ -1,6 +1,5 @@
 package com.fastcampus.board_admin_project.dto;
 
-import com.fastcampus.board_admin_project.domain.UserAccount;
 import com.fastcampus.board_admin_project.domain.constant.RoleType;
 
 import java.time.LocalDateTime;
@@ -8,7 +7,6 @@ import java.util.Set;
 
 public record UserAccountDto(
         String userId,
-        String userPassword,
         Set<RoleType> roleTypes,
         String email,
         String nickname,
@@ -19,40 +17,15 @@ public record UserAccountDto(
         String modifiedBy
 ) {
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo) {
-        return UserAccountDto.of(userId, userPassword, roleTypes, email, nickname, memo, null, null, null, null);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo) {
+        return UserAccountDto.of(userId, roleTypes, email, nickname, memo, null, null, null, null);
     }
 
 
 
-    public static UserAccountDto of(String userId, String userPassword, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(userId, userPassword, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, Set<RoleType> roleTypes, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, roleTypes, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-        );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo
-        );
-    }
 
 }

--- a/src/main/java/com/fastcampus/board_admin_project/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/board_admin_project/dto/security/BoardAdminPrincipal.java
@@ -2,7 +2,7 @@ package com.fastcampus.board_admin_project.dto.security;
 
 
 import com.fastcampus.board_admin_project.domain.constant.RoleType;
-import com.fastcampus.board_admin_project.dto.UserAccountDto;
+import com.fastcampus.board_admin_project.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -43,7 +43,7 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -54,8 +54,8 @@ public record BoardAdminPrincipal(
         );
     }
 
-    public UserAccountDto toDto(){
-        return UserAccountDto.of(
+    public AdminAccountDto toDto(){
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/board_admin_project/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/board_admin_project/repository/AdminAccountRepository.java
@@ -1,0 +1,8 @@
+package com.fastcampus.board_admin_project.repository;
+
+import com.fastcampus.board_admin_project.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+
+}

--- a/src/main/java/com/fastcampus/board_admin_project/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/board_admin_project/repository/UserAccountRepository.java
@@ -1,8 +1,0 @@
-package com.fastcampus.board_admin_project.repository;
-
-import com.fastcampus.board_admin_project.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
     ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
     ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
     ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),

--- a/src/test/java/com/fastcampus/board_admin_project/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/board_admin_project/controller/ArticleCommentManagementControllerTest.java
@@ -108,7 +108,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/board_admin_project/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/board_admin_project/controller/ArticleManagementControllerTest.java
@@ -107,7 +107,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/board_admin_project/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/board_admin_project/repository/JpaRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.board_admin_project.repository;
 
-import com.fastcampus.board_admin_project.domain.UserAccount;
+import com.fastcampus.board_admin_project.domain.AdminAccount;
 import com.fastcampus.board_admin_project.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원 정보 select 테스트")
@@ -35,10 +35,10 @@ class JpaRepositoryTest {
         // Given
 
         // When
-        List<UserAccount> userAccounts = userAccountRepository.findAll();
+        List<AdminAccount> adminAccounts = adminAccountRepository.findAll();
 
         // Then
-        assertThat(userAccounts)
+        assertThat(adminAccounts)
                 .isNotNull()
                 .hasSize(4);
     }
@@ -47,27 +47,27 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of("test", "pw", Set.of(RoleType.DEVELOPER), null, null, null);
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount + 1);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount + 1);
     }
 
     @DisplayName("회원 정보 update 테스트")
     @Test
     void givenUserAccountAndRoleType_whenUpdating_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -79,14 +79,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorksFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count()).isEqualTo(previousCount);
+        assertThat(adminAccountRepository.count()).isEqualTo(previousCount);
     }
 
 

--- a/src/test/java/com/fastcampus/board_admin_project/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/board_admin_project/service/ArticleCommentManagementServiceTest.java
@@ -171,7 +171,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
                 Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",

--- a/src/test/java/com/fastcampus/board_admin_project/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/board_admin_project/service/ArticleManagementServiceTest.java
@@ -173,7 +173,6 @@ class ArticleManagementServiceTest {
         private UserAccountDto createUserAccountDto() {
             return UserAccountDto.of(
                     "unoTest",
-                    "pw",
                     Set.of(RoleType.ADMIN),
                     "uno-test@email.com",
                     "uno-test",


### PR DESCRIPTION
기존의 관리자 회원 테이블명을 변경

This closes #26 